### PR TITLE
update repo to fit the current status of rust development

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,18 @@
+name: CI
+
+on: [push, pull_request]
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  prepush:
+    runs-on: ubuntu-latest
+    container: rust:latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+      - name: Install target
+        run: rustup target add thumbv7m-none-eabi
+      - name: Run
+        run: ./prepush

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,9 +26,10 @@ ssl = []
 hashbrown = "*"
 openssl = { version = "*", optional = true }
 rustls = { version = "^0.20.8", optional = true }
-webpki-roots = { version = "*", optional = true }
-rustls-pemfile = { version = "*", optional = true }
+webpki-roots = { version = "^0.26.0", optional = true }
+rustls-pemfile = { version = "^2.0.0", optional = true }
 native-tls = { version = "*", optional = true }
+url = { version = "2.5.3", default-features = false }
 
 [dev-dependencies]
 clap = { version = "*", features = ["derive"] }

--- a/examples/advance_client.rs
+++ b/examples/advance_client.rs
@@ -3,17 +3,17 @@ use std::net;
 
 use http_io::client::HttpRequestBuilder;
 use http_io::error::Result;
-use http_io::url::Url;
+use http_io::url::HttpUrl;
 
 fn main() -> Result<()> {
     let args = std::env::args();
-    let url: Url = args
+    let url: HttpUrl = args
         .skip(1)
         .next()
         .unwrap_or("http://www.google.com".into())
         .parse()?;
 
-    let s = net::TcpStream::connect((url.host_str().unwrap(), url.port_or_known_default().unwrap()))?;
+    let s = net::TcpStream::connect((url.host(), url.port()?))?;
     let mut response = HttpRequestBuilder::get(url)?.send(s)?.finish()?;
 
     println!("{:#?}", response.headers);

--- a/examples/advance_client.rs
+++ b/examples/advance_client.rs
@@ -13,7 +13,7 @@ fn main() -> Result<()> {
         .unwrap_or("http://www.google.com".into())
         .parse()?;
 
-    let s = net::TcpStream::connect((url.host(), url.port()?))?;
+    let s = net::TcpStream::connect((url.host(), url.port()))?;
     let mut response = HttpRequestBuilder::get(url)?.send(s)?.finish()?;
 
     println!("{:#?}", response.headers);

--- a/examples/advance_client.rs
+++ b/examples/advance_client.rs
@@ -13,7 +13,7 @@ fn main() -> Result<()> {
         .unwrap_or("http://www.google.com".into())
         .parse()?;
 
-    let s = net::TcpStream::connect((url.authority.as_ref(), url.port()?))?;
+    let s = net::TcpStream::connect((url.host_str().unwrap(), url.port_or_known_default().unwrap()))?;
     let mut response = HttpRequestBuilder::get(url)?.send(s)?.finish()?;
 
     println!("{:#?}", response.headers);

--- a/examples/connection_reuse.rs
+++ b/examples/connection_reuse.rs
@@ -5,16 +5,14 @@ use std::io;
 
 fn main() -> Result<()> {
     let args = std::env::args();
-    let url: Url = args
+    let host = args
         .skip(1)
         .next()
-        .unwrap_or("http://www.google.com".into())
-        .parse()?;
+        .unwrap_or("http://www.google.com".into());
 
     let mut client = HttpClient::<std::net::TcpStream>::new();
     for path in &["/", "/favicon.ico", "/robots.txt"] {
-        let mut url = url.clone();
-        url.path = path.parse()?;
+        let url = Url::parse(format!("{}{}", host, path).as_str())?;
         io::copy(&mut client.get(url)?.finish()?.body, &mut io::stdout())?;
     }
 

--- a/examples/connection_reuse.rs
+++ b/examples/connection_reuse.rs
@@ -9,10 +9,12 @@ fn main() -> Result<()> {
         .skip(1)
         .next()
         .unwrap_or("http://www.google.com".into());
+    let url = Url::parse(&host)?;
 
     let mut client = HttpClient::<std::net::TcpStream>::new();
     for path in &["/", "/favicon.ico", "/robots.txt"] {
-        let url = Url::parse(format!("{}{}", host, path).as_str())?;
+        let mut url = url.clone();
+        url.set_path(&path);
         io::copy(&mut client.get(url)?.finish()?.body, &mut io::stdout())?;
     }
 

--- a/examples/no_std.rs
+++ b/examples/no_std.rs
@@ -23,7 +23,7 @@ mod no_std {
     use http_io::error::{Error, Result};
     use http_io::io;
     use http_io::protocol::HttpMethod;
-    use http_io::url::Url;
+    use http_io::url::HttpUrl;
 
     #[derive(Parser)]
     struct Options {
@@ -106,9 +106,9 @@ mod no_std {
 
         // The clap parsing stuff relies on std::error::Error
         let method: HttpMethod = opts.method.parse()?;
-        let url: Url = opts.url.parse()?;
+        let url: HttpUrl = opts.url.parse()?;
 
-        let s = MyFakeTcpStream::connect(url.host_str().unwrap(), url.port_or_known_default().unwrap())?;
+        let s = MyFakeTcpStream::connect(url.host(), url.port()?)?;
 
         let mut body = match method {
             HttpMethod::Get => HttpRequestBuilder::get(url)?.send(s)?.finish()?.body,

--- a/examples/no_std.rs
+++ b/examples/no_std.rs
@@ -108,7 +108,7 @@ mod no_std {
         let method: HttpMethod = opts.method.parse()?;
         let url: Url = opts.url.parse()?;
 
-        let s = MyFakeTcpStream::connect(url.authority.as_ref(), url.port()?)?;
+        let s = MyFakeTcpStream::connect(url.host_str().unwrap(), url.port_or_known_default().unwrap())?;
 
         let mut body = match method {
             HttpMethod::Get => HttpRequestBuilder::get(url)?.send(s)?.finish()?.body,

--- a/examples/no_std.rs
+++ b/examples/no_std.rs
@@ -108,7 +108,7 @@ mod no_std {
         let method: HttpMethod = opts.method.parse()?;
         let url: HttpUrl = opts.url.parse()?;
 
-        let s = MyFakeTcpStream::connect(url.host(), url.port()?)?;
+        let s = MyFakeTcpStream::connect(url.host(), url.port())?;
 
         let mut body = match method {
             HttpMethod::Get => HttpRequestBuilder::get(url)?.send(s)?.finish()?.body,

--- a/prepush
+++ b/prepush
@@ -15,5 +15,6 @@ cargo test --no-default-features --features std,ssl-rustls
 cargo run --example readme
 cargo run --example connection_reuse
 cargo run --example no_std --no-default-features -- http://fake.com
+cargo build --target thumbv7m-none-eabi --no-default-features
 
 echo "All tests passed"

--- a/src/client.rs
+++ b/src/client.rs
@@ -26,7 +26,7 @@
 //!
 //! fn main() -> Result<()> {
 //!     let http_url: HttpUrl = "http://www.google.com".parse()?;
-//!     let s = TcpStream::connect((http_url.host(), http_url.port()?))?;
+//!     let s = TcpStream::connect((http_url.host(), http_url.port()))?;
 //!     let mut response = HttpRequestBuilder::get(http_url)?.send(s)?.finish()?;
 //!     println!("{:#?}", response.headers);
 //!     io::copy(&mut response.body, &mut io::stdout())?;
@@ -237,7 +237,7 @@ impl StreamConnector for std::net::TcpStream {
         };
 
         Ok(StreamId {
-            addr: std::net::ToSocketAddrs::to_socket_addrs(&(http_url.host(), http_url.port()?))
+            addr: std::net::ToSocketAddrs::to_socket_addrs(&(http_url.host(), http_url.port()))
                 .map_err(|_| err())?
                 .next()
                 .ok_or_else(err)?,

--- a/src/client.rs
+++ b/src/client.rs
@@ -20,14 +20,14 @@
 //! ```rust
 //! use http_io::client::HttpRequestBuilder;
 //! use http_io::error::Result;
-//! use http_io::url::Url;
+//! use http_io::url::HttpUrl;
 //! use std::io;
 //! use std::net::TcpStream;
 //!
 //! fn main() -> Result<()> {
-//!     let url: Url = "http://www.google.com".parse()?;
-//!     let s = TcpStream::connect((url.host_str().unwrap(), url.port_or_known_default().unwrap()))?;
-//!     let mut response = HttpRequestBuilder::get(url)?.send(s)?.finish()?;
+//!     let http_url: HttpUrl = "http://www.google.com".parse()?;
+//!     let s = TcpStream::connect((http_url.host(), http_url.port()?))?;
+//!     let mut response = HttpRequestBuilder::get(http_url)?.send(s)?.finish()?;
 //!     println!("{:#?}", response.headers);
 //!     io::copy(&mut response.body, &mut io::stdout())?;
 //!     Ok(())
@@ -41,10 +41,11 @@
 //! use std::io;
 //!
 //! fn main() -> Result<()> {
-//!     let host = "http://www.google.com";
+//!     let url = Url::parse("http://www.google.com")?;
 //!     let mut client = HttpClient::<std::net::TcpStream>::new();
 //!     for path in &["/", "/favicon.ico", "/robots.txt"] {
-//!         let url = Url::parse(format!("{}{}", host, path).as_str())?;
+//!         let mut url = url.clone();
+//!         url.set_path(&path);
 //!         io::copy(&mut client.get(url)?.finish()?.body, &mut io::stdout())?;
 //!     }
 //!     Ok(())
@@ -58,7 +59,7 @@ use crate::protocol::{HttpBody, HttpStatus};
 use crate::protocol::{HttpMethod, HttpRequest, OutgoingRequest};
 #[cfg(feature = "std")]
 use crate::url::Scheme;
-use crate::url::Url;
+use crate::url::{HttpUrl, Url};
 #[cfg(not(feature = "std"))]
 use alloc::string::{String, ToString as _};
 use core::convert::TryInto;
@@ -73,63 +74,63 @@ pub struct HttpRequestBuilder {
 
 impl HttpRequestBuilder {
     /// Create a `HttpRequestBuilder` to build a DELETE request
-    pub fn delete<U: TryInto<Url>>(url: U) -> Result<Self>
+    pub fn delete<U: TryInto<HttpUrl>>(url: U) -> Result<Self>
     where
-        <U as TryInto<Url>>::Error: Display,
+        <U as TryInto<HttpUrl>>::Error: Display,
     {
         HttpRequestBuilder::new(url, HttpMethod::Delete)
     }
 
     /// Create a `HttpRequestBuilder` to build a GET request
-    pub fn get<U: TryInto<Url>>(url: U) -> Result<Self>
+    pub fn get<U: TryInto<HttpUrl>>(url: U) -> Result<Self>
     where
-        <U as TryInto<Url>>::Error: Display,
+        <U as TryInto<HttpUrl>>::Error: Display,
     {
         HttpRequestBuilder::new(url, HttpMethod::Get)
     }
 
     /// Create a `HttpRequestBuilder` to build a HEAD request
-    pub fn head<U: TryInto<Url>>(url: U) -> Result<Self>
+    pub fn head<U: TryInto<HttpUrl>>(url: U) -> Result<Self>
     where
-        <U as TryInto<Url>>::Error: Display,
+        <U as TryInto<HttpUrl>>::Error: Display,
     {
         HttpRequestBuilder::new(url, HttpMethod::Head)
     }
 
     /// Create a `HttpRequestBuilder` to build an OPTIONS request
-    pub fn options<U: TryInto<Url>>(url: U) -> Result<Self>
+    pub fn options<U: TryInto<HttpUrl>>(url: U) -> Result<Self>
     where
-        <U as TryInto<Url>>::Error: Display,
+        <U as TryInto<HttpUrl>>::Error: Display,
     {
         HttpRequestBuilder::new(url, HttpMethod::Options)
     }
 
     /// Create a `HttpRequestBuilder` to build a POST request
-    pub fn post<U: TryInto<Url>>(url: U) -> Result<Self>
+    pub fn post<U: TryInto<HttpUrl>>(url: U) -> Result<Self>
     where
-        <U as TryInto<Url>>::Error: Display,
+        <U as TryInto<HttpUrl>>::Error: Display,
     {
         HttpRequestBuilder::new(url, HttpMethod::Post)
     }
 
     /// Create a `HttpRequestBuilder` to build a PUT request
-    pub fn put<U: TryInto<Url>>(url: U) -> Result<Self>
+    pub fn put<U: TryInto<HttpUrl>>(url: U) -> Result<Self>
     where
-        <U as TryInto<Url>>::Error: Display,
+        <U as TryInto<HttpUrl>>::Error: Display,
     {
         HttpRequestBuilder::new(url, HttpMethod::Put)
     }
 
     /// Create a `HttpRequestBuilder`. May fail if the given url does not parse.
-    pub fn new<U: TryInto<Url>>(url: U, method: HttpMethod) -> Result<Self>
+    pub fn new<U: TryInto<HttpUrl>>(url: U, method: HttpMethod) -> Result<Self>
     where
-        <U as TryInto<Url>>::Error: Display,
+        <U as TryInto<HttpUrl>>::Error: Display,
     {
-        let url: Url = url
+        let url: HttpUrl = url
             .try_into()
             .map_err(|e| Error::ParseError(e.to_string()))?;
-        let mut request = HttpRequest::new(method, url.path());
-        request.add_header("Host", url.host_str().unwrap().to_string());
+        let mut request = HttpRequest::new(method, url.url().path());
+        request.add_header("Host", url.host().to_string());
         request.add_header("User-Agent", "http_io");
         request.add_header("Accept", "*/*");
         if method.has_body() {
@@ -225,27 +226,23 @@ impl StreamConnector for std::net::TcpStream {
     }
 
     fn to_stream_addr(url: Url) -> Result<Self::StreamAddr> {
-        use std::str::FromStr;
-        let Some(host) = url.host_str() else {
-            return Err(crate::error::Error::UrlError(String::from("no host")))
-        };
-        let Some(port) = url.port_or_known_default() else {
-            return Err(crate::error::Error::UrlError(format!("port for {} not known", url.scheme())))
-        };
-        let scheme = Scheme::from_str(url.scheme())?;
+        use core::convert::TryFrom;
+
+        let http_url = HttpUrl::try_from(url)?;
         let err = || {
             std::io::Error::new(
                 std::io::ErrorKind::AddrNotAvailable,
-                format!("Failed to lookup {}", host),
+                format!("Failed to lookup {}", http_url.host()),
             )
         };
+
         Ok(StreamId {
-            addr: std::net::ToSocketAddrs::to_socket_addrs(&(host, port))
+            addr: std::net::ToSocketAddrs::to_socket_addrs(&(http_url.host(), http_url.port()?))
                 .map_err(|_| err())?
                 .next()
                 .ok_or_else(err)?,
-            host: String::from(host),
-            secure: Scheme::Https.eq(&scheme),
+            host: String::from(http_url.host()),
+            secure: Scheme::Https.eq(&http_url.scheme()),
         })
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,6 +1,6 @@
 use crate::protocol::{HttpMethod, HttpStatus};
 #[cfg(not(feature = "std"))]
-use alloc::string::String;
+use alloc::string::{String, ToString};
 use core::fmt;
 use core::num;
 use core::str;
@@ -78,5 +78,11 @@ impl From<Error> for std::io::Error {
 impl From<crate::ssl::Error> for Error {
     fn from(e: crate::ssl::Error) -> Self {
         Self::SslError(e)
+    }
+}
+
+impl From<url::ParseError> for Error {
+    fn from(e: url::ParseError) -> Self {
+        Self::ParseError(e.to_string())
     }
 }

--- a/src/server.rs
+++ b/src/server.rs
@@ -59,7 +59,6 @@
 //!         Ok(())
 //!     });
 //!
-//!
 //!     let url = format!("http://127.0.0.1:{}/src/server.rs", port);
 //!     let mut body = http_io::client::get(url.as_ref())?;
 //!     io::copy(&mut body, &mut std::io::stdout())?;

--- a/src/server.rs
+++ b/src/server.rs
@@ -59,7 +59,8 @@
 //!         Ok(())
 //!     });
 //!
-//!     let url = format!("http://localhost:{}/src/server.rs", port);
+//!
+//!     let url = format!("http://127.0.0.1:{}/src/server.rs", port);
 //!     let mut body = http_io::client::get(url.as_ref())?;
 //!     io::copy(&mut body, &mut std::io::stdout())?;
 //!     handle.join().unwrap()?;

--- a/src/ssl/mod.rs
+++ b/src/ssl/mod.rs
@@ -1,4 +1,6 @@
-#[allow(dead_code)] // disable warning of not using the String in the Error
+// disable false positive of not using the String, the dead code analysis
+// intentionally ignore we derive the Debug trait
+#[allow(dead_code)]
 #[derive(Debug)]
 pub struct Error(String);
 

--- a/src/ssl/mod.rs
+++ b/src/ssl/mod.rs
@@ -1,3 +1,4 @@
+#[allow(unused)]
 #[derive(Debug)]
 pub struct Error(String);
 

--- a/src/ssl/mod.rs
+++ b/src/ssl/mod.rs
@@ -1,4 +1,4 @@
-#[allow(unused)]
+#[allow(dead_code)] // disable warning of not using the String in the Error
 #[derive(Debug)]
 pub struct Error(String);
 

--- a/src/ssl/rustls.rs
+++ b/src/ssl/rustls.rs
@@ -22,16 +22,15 @@ fn root_store() -> Result<rustls::RootCertStore> {
         rustls::OwnedTrustAnchor::from_subject_spki_name_constraints(
             ta.subject.to_vec(),
             ta.subject_public_key_info.to_vec(),
-            match ta.name_constraints.as_ref() {
-                Some(v) => Option::Some(v.to_vec()),
-                None => Option::None,
-            },
+            ta.name_constraints.as_ref().map(|c| c.to_vec()),
         )
     }));
 
     #[cfg(test)]
     for c in rustls_pemfile::certs(&mut io::BufReader::new(&read_test_cert("test_ca.pem")?[..])) {
-        root_store.add(&rustls::Certificate(c?.to_vec())).map_err(|e| Error(e.to_string()))?;
+        root_store
+            .add(&rustls::Certificate(c?.to_vec()))
+            .map_err(|e| Error(e.to_string()))?;
     }
 
     Ok(root_store)

--- a/src/ssl/rustls.rs
+++ b/src/ssl/rustls.rs
@@ -2,12 +2,7 @@ use super::{Error, Result};
 use crate::io;
 use crate::server::Listen;
 use std::convert::TryInto as _;
-
-#[cfg(feature = "std")]
 use std::sync::Arc;
-
-#[cfg(not(feature = "std"))]
-use alloc::sync::Arc;
 
 #[cfg(test)]
 fn read_test_cert(name: &str) -> Result<Vec<u8>> {
@@ -23,20 +18,20 @@ fn read_test_cert(name: &str) -> Result<Vec<u8>> {
 
 fn root_store() -> Result<rustls::RootCertStore> {
     let mut root_store = rustls::RootCertStore::empty();
-    root_store.add_server_trust_anchors(webpki_roots::TLS_SERVER_ROOTS.0.iter().map(|ta| {
+    root_store.add_server_trust_anchors(webpki_roots::TLS_SERVER_ROOTS.iter().map(|ta| {
         rustls::OwnedTrustAnchor::from_subject_spki_name_constraints(
-            ta.subject,
-            ta.spki,
-            ta.name_constraints,
+            ta.subject.to_vec(),
+            ta.subject_public_key_info.to_vec(),
+            match ta.name_constraints.as_ref() {
+                Some(v) => Option::Some(v.to_vec()),
+                None => Option::None,
+            },
         )
     }));
 
     #[cfg(test)]
-    for c in rustls_pemfile::certs(&mut io::BufReader::new(&read_test_cert("test_ca.pem")?[..]))?
-        .iter()
-        .map(|v| rustls::Certificate(v.clone()))
-    {
-        root_store.add(&c).map_err(|e| Error(e.to_string()))?;
+    for c in rustls_pemfile::certs(&mut io::BufReader::new(&read_test_cert("test_ca.pem")?[..])) {
+        root_store.add(&rustls::Certificate(c?.to_vec())).map_err(|e| Error(e.to_string()))?;
     }
 
     Ok(root_store)
@@ -138,13 +133,15 @@ pub struct SslListener<L> {
 impl<L: Listen> SslListener<L> {
     pub fn new(private_key_pem: &[u8], cert_pem: &[u8], listener: L) -> Result<Self> {
         let private_key = rustls::PrivateKey(
-            rustls_pemfile::pkcs8_private_keys(&mut io::BufReader::new(private_key_pem))?[0]
-                .clone(),
+            rustls_pemfile::private_key(&mut io::BufReader::new(private_key_pem))?
+                .unwrap()
+                .secret_der()
+                .to_vec(),
         );
-        let certs = rustls_pemfile::certs(&mut io::BufReader::new(cert_pem))?
-            .iter()
-            .map(|v| rustls::Certificate(v.clone()))
-            .collect();
+        let mut certs = Vec::new();
+        for cert in rustls_pemfile::certs(&mut io::BufReader::new(cert_pem)) {
+            certs.push(rustls::Certificate(cert?.to_vec()));
+        }
 
         let config = rustls::ServerConfig::builder()
             .with_safe_defaults()

--- a/src/url.rs
+++ b/src/url.rs
@@ -49,7 +49,7 @@ pub struct HttpUrl {
 
 impl HttpUrl {
     pub fn port(&self) -> u16 {
-        // this should always go to the happy path as we only have scheme of http and https
+        // this will never fail because we verified the scheme is HTTP or HTTPS which should always have a port
         self.url.port_or_known_default().unwrap()
     }
     pub fn scheme(&self) -> Scheme {
@@ -78,7 +78,7 @@ impl TryFrom<Url> for HttpUrl {
         if scheme != Scheme::Http && scheme != Scheme::Https {
             return Err(error_unsupported_url_scheme(url.scheme()));
         };
-        // host must exist in http and https, and url crate ensure about it, see test check_url_must_have_host
+        // HTTP and HTTPS URLs must always have a host, see the check_url_must_have_host test
         let host = url.host_str().unwrap();
         Ok(Self {
             scheme,

--- a/src/url.rs
+++ b/src/url.rs
@@ -1,30 +1,9 @@
-//! A RFC 3986 URL
-//!
-//! # Example
-//! ```rust
-//! use http_io::url;
-//!
-//! let url: url::Url = "http://user:pass@www.google.com:8080/foo?bar#baz".parse().unwrap();
-//! assert_eq!(url.scheme, url::Scheme::Http);
-//! assert_eq!(url.authority, "www.google.com");
-//! assert_eq!(url.port, Some(8080));
-//! assert_eq!(url.path, "/foo".parse().unwrap());
-//! assert_eq!(url.query, Some("bar".into()));
-//! assert_eq!(url.fragment, Some("baz".into()));
-//! assert_eq!(url.user_information, Some("user:pass".into()));
-//! ```
 use crate::error::{Error, Result};
-use crate::protocol::Parser;
 #[cfg(not(feature = "std"))]
-use alloc::{
-    format,
-    string::{String, ToString},
-    vec,
-    vec::Vec,
-};
-use core::convert::TryFrom;
+use alloc::string::String;
 use core::fmt;
 use core::str;
+pub use url::Url;
 
 #[derive(PartialEq, Debug, Clone)]
 pub enum Scheme {
@@ -58,337 +37,16 @@ impl fmt::Display for Scheme {
     }
 }
 
-fn percent_encode_char(c: char) -> String {
-    c.to_string()
-        .bytes()
-        .map(|b| format!("%{:x}", b))
-        .collect::<Vec<_>>()
-        .join("")
-}
-
-fn is_unreserved_char(c: char) -> bool {
-    (c >= 'a' && c <= 'z')
-        || (c >= 'A' && c <= 'Z')
-        || (c >= '0' && c <= '9')
-        || c == '-'
-        || c == '.'
-        || c == '_'
-        || c == '~'
-}
-
-fn percent_encode(s: &str) -> String {
-    s.chars()
-        .map(|c| {
-            if is_unreserved_char(c) {
-                c.to_string()
-            } else {
-                percent_encode_char(c)
-            }
-        })
-        .collect::<Vec<_>>()
-        .join("")
-}
-
-#[test]
-fn percent_encode_unreserved_chars_not_encoded() {
-    let s = "abcdefghijklmnopqrstuvqxyzABCDEFGHIJKLMNOPQRSTUVQXYZ0123456789-._~";
-    assert_eq!(percent_encode(s), s);
-}
-
-#[test]
-fn percent_encode_reserved_chars_encoded() {
-    let s = "abcd/#$@%@(&%&!*@#)$%@!#dsfsdf0932510294";
-    assert_eq!(
-        percent_encode(s),
-        "abcd%2f%23%24%40%25%40%28%26%25%26%21%2a%40%23%29%24%25%40%21%23dsfsdf0932510294"
-    );
-}
-
-#[test]
-fn percent_encode_multi_byte() {
-    assert_eq!(percent_encode("À"), "%c3%80");
-    assert_eq!(percent_encode("ア"), "%e3%82%a2");
-    assert_eq!(percent_encode("💖"), "%f0%9f%92%96");
-}
-
-fn percent_decode(s: &str) -> Result<String> {
-    let mut decoded = vec![];
-    let mut parser = Parser::new(s);
-    while let Some(c) = parser.parse_char().ok() {
-        if c == '%' {
-            let h1 = parser.parse_char()?;
-            let h2 = parser.parse_char()?;
-            decoded.push(u8::from_str_radix(&format!("{}{}", h1, h2), 16)?);
-        } else {
-            decoded.push(c as u8);
-        }
-    }
-    Ok(str::from_utf8(&decoded)?.into())
-}
-
-#[test]
-fn percent_decode_single_byte() {
-    assert_eq!(percent_decode("%2f").unwrap(), "/");
-    assert_eq!(percent_decode("%2F").unwrap(), "/");
-    assert!(percent_decode("%a1").is_err());
-}
-
-#[test]
-fn percent_decode_multi_byte() {
-    assert_eq!(percent_decode("%c3%80").unwrap(), "À");
-    assert_eq!(percent_decode("%e3%82%A2").unwrap(), "ア");
-    assert_eq!(percent_decode("%f0%9f%92%96").unwrap(), "💖");
-}
-
-#[test]
-fn percent_encode_round_trip() {
-    let s = "abcd/#$@%@(&%&!*@#)$%@!#dsfsdf0932510294";
-    assert_eq!(percent_decode(&percent_encode(s)).unwrap(), s);
-}
-
-#[test]
-fn percent_decode_error() {
-    assert!(percent_decode("%FG").is_err());
-}
-
-#[derive(PartialEq, Debug, Clone)]
-pub struct Path {
-    components: Vec<String>,
-    trailing_slash: bool,
-}
-
-#[cfg(test)]
-impl Path {
-    fn new(components: &[&str], trailing_slash: bool) -> Self {
-        Self {
-            components: components.iter().map(|&c| c.into()).collect(),
-            trailing_slash,
-        }
-    }
-}
-
-impl Path {
-    pub fn components(&self) -> impl Iterator<Item = &str> {
-        self.components.iter().map(|c| c.as_str())
-    }
-
-    pub fn trailing_slash(&self) -> bool {
-        self.trailing_slash
-    }
-
-    pub fn push(&mut self, component: &str) {
-        self.components.push(component.into());
-        self.trailing_slash = false;
-    }
-}
-
-#[test]
-fn path_components() {
-    let path = Path::new(&["a", "b", "c"], false);
-    assert_eq!(path.components().collect::<Vec<_>>(), vec!["a", "b", "c"])
-}
-
-#[test]
-fn path_push() {
-    let mut path = Path::new(&["a", "b"], true);
-    assert_eq!(path.to_string(), "/a/b/");
-    path.push("c");
-    assert_eq!(path.to_string(), "/a/b/c");
-}
-
-impl fmt::Display for Path {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        if self.components.is_empty() {
-            write!(f, "{}", if self.trailing_slash { "/" } else { "" })
-        } else {
-            write!(
-                f,
-                "/{}{}",
-                self.components
-                    .iter()
-                    .map(|c| percent_encode(c.as_ref()))
-                    .collect::<Vec<_>>()
-                    .join("/"),
-                if self.trailing_slash { "/" } else { "" }
-            )
-        }
-    }
-}
-
-impl str::FromStr for Path {
-    type Err = Error;
-
-    fn from_str(s: &str) -> Result<Self> {
-        Ok(Path {
-            components: s
-                .split('/')
-                .filter(|s| !s.is_empty())
-                .map(percent_decode)
-                .collect::<Result<Vec<_>>>()?,
-            trailing_slash: s.ends_with("/"),
-        })
-    }
-}
-
-#[derive(PartialEq, Debug, Clone)]
-pub struct Url {
-    pub scheme: Scheme,
-    pub authority: String,
-    pub port: Option<u16>,
-    pub path: Path,
-    pub query: Option<String>,
-    pub fragment: Option<String>,
-    pub user_information: Option<String>,
-}
-
-impl Url {
-    #[cfg(test)]
-    fn new<S1: Into<String>, S2: Into<String>, S3: Into<String>, S4: Into<String>>(
-        scheme: Scheme,
-        authority: S1,
-        port: Option<u16>,
-        path: Path,
-        query: Option<S2>,
-        fragment: Option<S3>,
-        user_information: Option<S4>,
-    ) -> Self {
-        Self {
-            scheme,
-            authority: authority.into(),
-            port,
-            path,
-            query: query.map(Into::into),
-            fragment: fragment.map(Into::into),
-            user_information: user_information.map(Into::into),
-        }
-    }
-
-    pub fn path(&self) -> String {
-        format!(
-            "{}{}{}",
-            self.path,
-            self.query
-                .as_ref()
-                .map(|d| format!("?{}", percent_encode(d)))
-                .unwrap_or_else(|| "".into()),
-            self.fragment
-                .as_ref()
-                .map(|d| format!("#{}", percent_encode(d)))
-                .unwrap_or_else(|| "".into()),
-        )
-    }
-
-    pub fn port(&self) -> Result<u16> {
-        if let Some(p) = self.port {
-            return Ok(p);
-        }
-        match &self.scheme {
-            Scheme::Http => Ok(80),
-            Scheme::Https => Ok(443),
-            s => Err(Error::UrlError(format!("port for {} not known", s))),
-        }
-    }
-}
-
-impl TryFrom<&str> for Url {
-    type Error = Error;
-    fn try_from(value: &str) -> Result<Self> {
-        value.parse()
-    }
-}
-
-impl fmt::Display for Url {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(
-            f,
-            "{}://{}{}{}{}",
-            self.scheme,
-            self.user_information
-                .as_ref()
-                .map(|d| format!("{}@", d))
-                .unwrap_or_else(|| "".into()),
-            self.authority,
-            self.port
-                .as_ref()
-                .map(|d| format!(":{}", d))
-                .unwrap_or_else(|| "".into()),
-            self.path()
-        )
-    }
-}
-
-impl str::FromStr for Url {
-    type Err = Error;
-
-    fn from_str(s: &str) -> Result<Self> {
-        let mut parser = Parser::new(s);
-
-        let scheme: Scheme = str::parse(parser.parse_until(":")?)?;
-        parser.expect("://")?;
-
-        let user_information = match parser.parse_until("@") {
-            Ok(info) => {
-                parser.expect("@").unwrap();
-                Some(info.into())
-            }
-            _ => None,
-        };
-
-        let authority = parser
-            .parse_until_any(&['/', '?', '#', ':'])
-            .or_else(|_| parser.parse_remaining())?
-            .into();
-
-        let port = match parser.expect(":") {
-            Ok(_) => Some(
-                parser
-                    .parse_until_any(&['/', '?', '#'])
-                    .or_else(|_| parser.parse_remaining())?
-                    .parse()?,
-            ),
-            _ => None,
-        };
-
-        let path = parser
-            .parse_until_any(&['?', '#'])
-            .or_else(|_| parser.parse_remaining())
-            .unwrap_or("")
-            .parse()?;
-
-        let query = match parser.expect("?") {
-            Ok(_) => Some(percent_decode(
-                parser
-                    .parse_until("#")
-                    .or_else(|_| parser.parse_remaining())
-                    .unwrap_or(""),
-            )?),
-            Err(_) => None,
-        };
-
-        let fragment = match parser.expect("#") {
-            Ok(_) => Some(percent_decode(parser.parse_remaining().unwrap_or(""))?),
-            Err(_) => None,
-        };
-
-        Ok(Self {
-            scheme,
-            authority,
-            port,
-            path,
-            query,
-            fragment,
-            user_information,
-        })
-    }
-}
 
 #[cfg(test)]
 mod tests {
+    extern crate std;
     use super::*;
+    use std::str::FromStr;
 
     fn round_trip_test(s: &str) {
         let url: Url = str::parse(s).unwrap();
-        assert_eq!(&format!("{}", url), s);
+        assert_eq!(&std::format!("{}", url), s);
     }
 
     #[test]
@@ -413,23 +71,17 @@ mod tests {
         scheme: Scheme,
         authority: &str,
         port: Option<u16>,
-        path: &[&str],
-        trailing_slash: bool,
+        path: &str,
         query: Option<&str>,
         fragment: Option<&str>,
-        user_information: Option<&str>,
     ) {
-        let actual_url: Url = str::parse(input).unwrap();
-        let expected_url = Url::new(
-            scheme,
-            authority,
-            port,
-            Path::new(path, trailing_slash),
-            query,
-            fragment,
-            user_information,
-        );
-        assert_eq!(actual_url, expected_url);
+        let url = Url::parse(input).unwrap();
+        assert_eq!(Scheme::from_str(url.scheme()).unwrap(), scheme);
+        assert_eq!(url.authority(), authority);
+        assert_eq!(url.port(), port);
+        assert_eq!(url.path(), path);
+        assert_eq!(url.query(), query);
+        assert_eq!(url.fragment(), fragment);
     }
 
     #[test]
@@ -439,9 +91,7 @@ mod tests {
             Scheme::Http,
             "google.com",
             None,
-            &[],
-            false,
-            None,
+            "/",
             None,
             None,
         );
@@ -450,9 +100,7 @@ mod tests {
             Scheme::Https,
             "google.com",
             None,
-            &[],
-            true,
-            None,
+            "/",
             None,
             None,
         );
@@ -461,9 +109,7 @@ mod tests {
             Scheme::Https,
             "google.com",
             None,
-            &["a", "b", "c"],
-            true,
-            None,
+            "/a/b/c/",
             None,
             None,
         );
@@ -472,24 +118,7 @@ mod tests {
             Scheme::Other("ftp".into()),
             "www.google.com",
             None,
-            &["a", "b", "c"],
-            false,
-            None,
-            None,
-            None,
-        );
-    }
-
-    #[test]
-    fn parse_path_encoding() {
-        parse_test(
-            "http://google.com/%2ffoo%2fbar",
-            Scheme::Http,
-            "google.com",
-            None,
-            &["/foo/bar"],
-            false,
-            None,
+            "/a/b/c",
             None,
             None,
         );
@@ -502,10 +131,8 @@ mod tests {
             Scheme::Http,
             "google.com",
             None,
-            &[],
-            false,
+            "/",
             Some("foobar"),
-            None,
             None,
         );
     }
@@ -517,11 +144,9 @@ mod tests {
             Scheme::Http,
             "google.com",
             None,
-            &[],
-            false,
+            "/",
             None,
             Some("foobar"),
-            None,
         );
     }
 
@@ -532,11 +157,9 @@ mod tests {
             Scheme::Http,
             "google.com",
             None,
-            &[],
-            false,
+            "/",
             Some("foo"),
             Some("bar"),
-            None,
         );
     }
 
@@ -547,11 +170,9 @@ mod tests {
             Scheme::Http,
             "google.com",
             None,
-            &[],
-            false,
+            "/",
             None,
             Some("bar?foo"),
-            None,
         );
     }
 
@@ -560,13 +181,11 @@ mod tests {
         parse_test(
             "https://user:pass@google.com/something",
             Scheme::Https,
-            "google.com",
+            "user:pass@google.com",
             None,
-            &["something"],
-            false,
+            "/something",
             None,
             None,
-            Some("user:pass"),
         );
     }
 
@@ -575,32 +194,30 @@ mod tests {
         parse_test(
             "http://google.com:8080#foobar",
             Scheme::Http,
-            "google.com",
+            "google.com:8080",
             Some(8080),
-            &[],
-            false,
+            "/",
             None,
             Some("foobar"),
-            None,
         );
     }
 
     #[test]
     fn scheme_to_port() -> Result<()> {
-        let url: Url = "http://google.com".parse()?;
-        assert_eq!(url.port()?, 80);
+        let url = Url::parse("http://google.com").unwrap();
+        assert_eq!(url.port_or_known_default(), Option::Some(80));
 
-        let url: Url = "https://google.com".parse()?;
-        assert_eq!(url.port()?, 443);
+        let url = Url::parse("https://google.com").unwrap();
+        assert_eq!(url.port_or_known_default(), Option::Some(443));
 
-        let url: Url = "http://google.com:9090".parse()?;
-        assert_eq!(url.port()?, 9090);
+        let url = Url::parse("http://google.com:9090").unwrap();
+        assert_eq!(url.port_or_known_default(), Option::Some(9090));
 
-        let url: Url = "file://google.com".parse()?;
-        assert!(url.port().is_err());
+        let url = Url::parse("file://google.com").unwrap();
+        assert_eq!(url.port_or_known_default(), Option::None);
 
-        let url: Url = "derp://google.com".parse()?;
-        assert!(url.port().is_err());
+        let url = Url::parse("derp://google.com").unwrap();
+        assert_eq!(url.port_or_known_default(), Option::None);
 
         Ok(())
     }


### PR DESCRIPTION
1, use url crate as a replacement of former one
2, upgrade version of rustls_pemfile to make test run 
3, upgrade version of webpki-roots to make test run 
4, add no_std build test of no_std target in prepush script

this PR relate to #10 